### PR TITLE
Prevent an infinite loop when the trimmed text is shorter than the condensed length

### DIFF
--- a/jquery.condense.js
+++ b/jquery.condense.js
@@ -94,7 +94,7 @@
       delta = clone.html().length - cloneTextLength; 
       debug ("condensing... [html-length:"+cloneHtmlLength+" text-length:"+cloneTextLength+" delta: "+delta+" break-point: "+loc+"]");
     //is the length of the clone text long enough?
-    }while(clone.text().length < opts.condensedLength )
+    }while(delta && clone.text().length < opts.condensedLength )
 
     //  after skipping ahead to the delimiter, do we still have enough trailing text?
     if ((fulltext.length - cloneTextLength) < opts.minTrail){


### PR DESCRIPTION
When the contents of the element are only text (`clone.html().length == clone.text().length`) and the substring is as long as or longer than the condensed length (`loc >= opts.condensedLength`) and the trimmed body is shorter than the condensed length (`clone.text().length < opts.condensedLength`), then `delta` will be zero and the `do`/`while` loop will be stuck in an infinite loop. Here's an example where this reliably happens:

``` html
<div id="demo">
              I wandered around the streets interviewing people and filming the sights on the day of the Royal wedding, I've never seen so many Union Jacks.

              Shot at 50fps using a Canon 7D, and because I didn't have my sound device I also used it to record the audio, holding it on the end of the tripod like a microphone.

              Music Soda by Cinematic Orchestra 

              twitter.com/davedingo
</div>
```

Then run this code:

``` javascript
$('#demo').condense({condensedLength: 400});
```
