### PR TITLE
Fixed infinite loop that cause the browser to be completely unresponsive

### DIFF
--- a/jquery.condense.js
+++ b/jquery.condense.js
@@ -58,12 +58,12 @@
 
         $('.condense_control_more',clone).click(function(){
           debug('moreControl clicked.');
-          triggerExpand($(this),o)
+          triggerExpand($(this),o);
         });
 
         $('.condense_control_less',$this).click(function(){
           debug('lessControl clicked.');
-          triggerCondense($(this),o)
+          triggerCondense($(this),o);
         });
       }
 
@@ -89,7 +89,7 @@
       // find the location of the next potential break-point.
       var loc = findDelimiterLocation(fullbody, opts.delim, (opts.condensedLength + delta));
       //set the html of the clone to the substring html of the original
-      clone.html($.trim(fullbody.substring(0,(loc+1))));
+      clone.html(fullbody.substring(0,(loc+1)));
       var cloneTextLength = clone.text().length;
       var cloneHtmlLength = clone.html().length;
       delta = clone.html().length - cloneTextLength; 


### PR DESCRIPTION
When finding the biggest string that will fit into the defined length, there is a possibility that the algorithm would fall in an infinite loop.

It would happen when after the first run of the algorithm, it would use a delta between current and expected.
When is goes to look for the next text delimiter and that is in the beginning of the segment being scanned, it will return same position that was passed in. Then outer cycle will add 1 to that index to avoid infinite loop, but then the $.trim(), will remove it, making the algorithm fall in a infinite loop.