### PR TITLE
Fixed infinite loop where while finding next delimiter, it would fall in the last tag

### DIFF
--- a/jquery.condense.js
+++ b/jquery.condense.js
@@ -165,7 +165,9 @@
 
 
     function isInsideTag(html, loc){
-        return (html.indexOf('>',loc) < html.indexOf('<',loc));
+        var startTagIndex = html.indexOf('<', loc);
+        var endTagIndex = html.indexOf('>', loc);
+        return (startTagIndex === -1 && endTagIndex >0) || (endTagIndex < startTagIndex);
     }
 
 


### PR DESCRIPTION
Algorithm found to be getting in infinite loop in very specific case because the function "isInsideTag()" was flawed when there are no more tags starting and there is more content after the last tag.
